### PR TITLE
chore(EAV-269): update meteor's yarn.lock

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -6,7 +6,6 @@ on:
       - "master"
       - "release50"
       - "EAV-*"
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -2180,7 +2180,7 @@ __metadata:
   resolution: "@sofie-automation/shared-lib@portal:../packages/shared-lib::locator=automation-core%40workspace%3A."
   dependencies:
     "@mos-connection/model": ^3.0.4
-    timeline-state-resolver-types: 9.0.1-tv2norge.0
+    timeline-state-resolver-types: 9.0.1-nightly-release50-20240619-123114-9c40a70f3.0
     tslib: ^2.4.0
     type-fest: ^2.19.0
   languageName: node
@@ -12451,12 +12451,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timeline-state-resolver-types@npm:9.0.1-tv2norge.0":
-  version: 9.0.1-tv2norge.0
-  resolution: "timeline-state-resolver-types@npm:9.0.1-tv2norge.0"
+"timeline-state-resolver-types@npm:9.0.1-nightly-release50-20240619-123114-9c40a70f3.0":
+  version: 9.0.1-nightly-release50-20240619-123114-9c40a70f3.0
+  resolution: "timeline-state-resolver-types@npm:9.0.1-nightly-release50-20240619-123114-9c40a70f3.0"
   dependencies:
     tslib: ^2.5.1
-  checksum: 77aa8c21a467533b33b59811f699c20665a28160597c7d07ea8c4cdbca178f534725cd8f317efd454edbcd10e54aa41248dc226df221fbe8f92edcf999caae3c
+  checksum: c0499f55eb7cc4be4e8d49466dc8abae89ed62fb21cb2cc30580e2bd1c9c8fcd6cd2fb5fad1c440ffac6245f13c1e30eadfb6186f316c45b96b0c4c5815662aa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
missing after TSR update in 30d3752e
