### PR TITLE
fix(EAV-371): playout-gateway not passing datastore to tsr at startup

### DIFF
--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -17,6 +17,7 @@ import {
 	SlowFulfilledCommandInfo,
 	DeviceStatus,
 	StatusCode,
+	Datastore,
 } from 'timeline-state-resolver'
 import { CoreHandler, CoreTSRDeviceHandler } from './coreHandler'
 import * as crypto from 'crypto'
@@ -224,6 +225,7 @@ export class TSRHandler {
 		this._triggerupdateTimelineAndMappings('TSRHandler.init(), later')
 		this.onSettingsChanged()
 		this._triggerUpdateDevices()
+		this._triggerUpdateDatastore()
 		this.logger.debug('tsr init done')
 	}
 
@@ -1067,12 +1069,12 @@ export class TSRHandler {
 		const datastoreObjs = datastoreCollection.find({
 			studioId: peripheralDevice.studioId,
 		})
-		const datastore: Record<string, any> = {}
+		const datastore: Datastore = {}
 		for (const { key, value, modified } of datastoreObjs) {
 			datastore[key] = { value, modified }
 		}
 
-		this.logger.debug(datastore)
+		this.logger.debug('datastore', datastore)
 		this.tsr.setDatastore(datastore)
 	}
 	/**


### PR DESCRIPTION
This is a cherry-pick from NRK, from release51, but compatible with release50