### PR TITLE
fix(EAV-518): offset lookaheads following other lookaheads by 1

### DIFF
--- a/packages/job-worker/src/playout/lookahead/__tests__/__snapshots__/lookahead.test.ts.snap
+++ b/packages/job-worker/src/playout/lookahead/__tests__/__snapshots__/lookahead.test.ts.snap
@@ -25,7 +25,7 @@ exports[`Lookahead got some objects 1`] = `
     "disabled": false,
     "enable": {
       "end": "#piece1obj1.start",
-      "start": "#piece0obj0.start + 0",
+      "start": "#piece0obj0.start + 1",
     },
     "id": "lookahead_timed1_piece1obj1",
     "isLookahead": true,
@@ -101,7 +101,7 @@ exports[`Lookahead got some objects 1`] = `
     "disabled": false,
     "enable": {
       "end": "#piece0obj6.start",
-      "start": "#piece1obj5.start + 0",
+      "start": "#piece1obj5.start + 1",
     },
     "id": "lookahead_timed1_piece0obj6",
     "isLookahead": true,
@@ -115,7 +115,7 @@ exports[`Lookahead got some objects 1`] = `
     },
     "disabled": false,
     "enable": {
-      "start": "#piece0obj6.start + 0",
+      "start": "#piece0obj6.start + 1",
     },
     "id": "lookahead_future0_piece1obj7",
     "isLookahead": true,

--- a/packages/job-worker/src/playout/lookahead/index.ts
+++ b/packages/job-worker/src/playout/lookahead/index.ts
@@ -191,7 +191,7 @@ const calculateStartAfterPreviousObj = (
 	const prevHasDelayFlag = (prevObj.classes || []).indexOf('_lookahead_start_delay') !== -1
 
 	// Start with previous piece
-	const startOffset = prevHasDelayFlag ? 2000 : 0
+	const startOffset = prevHasDelayFlag ? 2000 : 1 // has to be 1, because 0 causes a clash with previous object in superfly-timeline
 	return {
 		start: `${getStartOfObjectRef(prevObj)} + ${startOffset}`,
 	}


### PR DESCRIPTION
This is a hack that makes lookaheads work until superfly-timeline is fixed (see https://github.com/SuperFlyTV/supertimeline/pull/105). So far it seems to work fine and produce no side-effects.
