### PR TITLE
feat(EAV-603): additions to onTake and onSetAsNext contexts

### DIFF
--- a/packages/blueprints-integration/src/context/onSetAsNextContext.ts
+++ b/packages/blueprints-integration/src/context/onSetAsNextContext.ts
@@ -19,6 +19,9 @@ export interface IOnSetAsNextContext extends IShowStyleUserContext, IEventContex
 	/** Information about the current loop, if there is one */
 	readonly quickLoopInfo: BlueprintQuickLookInfo | null
 
+	/** Whether the part being set as next was selected as a result of user's actions */
+	readonly manuallySelected: boolean
+
 	/**
 	 * Data fetching
 	 */

--- a/packages/blueprints-integration/src/context/onTakeContext.ts
+++ b/packages/blueprints-integration/src/context/onTakeContext.ts
@@ -1,4 +1,4 @@
-import { IEventContext, IShowStyleUserContext, Time } from '..'
+import { IBlueprintPart, IBlueprintPiece, IEventContext, IShowStyleUserContext, Time } from '..'
 import { IPartAndPieceActionContext } from './partsAndPieceActionContext'
 import { IExecuteTSRActionsContext } from './executeTsrActionContext'
 
@@ -18,4 +18,6 @@ export interface IOnTakeContext
 	 * but the next part will not be taken.
 	 */
 	abortTake(): void
+	/** Insert a queued part to follow the taken part */
+	queuePartAfterTake(part: IBlueprintPart, pieces: IBlueprintPiece[]): void
 }

--- a/packages/job-worker/src/blueprints/__tests__/context-OnSetAsNextContext.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/context-OnSetAsNextContext.test.ts
@@ -8,7 +8,7 @@ import { PartAndPieceInstanceActionService } from '../context/services/PartAndPi
 import { OnSetAsNextContext } from '../context'
 
 describe('Test blueprint api context', () => {
-	async function getTestee() {
+	async function getTestee(setManually = false) {
 		const mockActionService = mock<PartAndPieceInstanceActionService>()
 		const context = new OnSetAsNextContext(
 			{
@@ -19,7 +19,8 @@ describe('Test blueprint api context', () => {
 			mock<PlayoutModel>(),
 			mock<ProcessedShowStyleCompound>(),
 			mock<WatchedPackagesHelper>(),
-			mockActionService
+			mockActionService,
+			setManually
 		)
 
 		return {
@@ -28,7 +29,7 @@ describe('Test blueprint api context', () => {
 		}
 	}
 
-	describe('ActionExecutionContext', () => {
+	describe('OnSetAsNextContext', () => {
 		test('getPartInstance', async () => {
 			const { context, mockActionService } = await getTestee()
 
@@ -125,6 +126,18 @@ describe('Test blueprint api context', () => {
 			await context.updatePartInstance('next', { title: 'My Part' } as Partial<IBlueprintMutatablePart<unknown>>)
 			expect(mockActionService.updatePartInstance).toHaveBeenCalledTimes(1)
 			expect(mockActionService.updatePartInstance).toHaveBeenCalledWith('next', { title: 'My Part' })
+		})
+
+		test('manuallySelected when false', async () => {
+			const { context } = await getTestee(false)
+
+			expect(context.manuallySelected).toBe(false)
+		})
+
+		test('manuallySelected when true', async () => {
+			const { context } = await getTestee(true)
+
+			expect(context.manuallySelected).toBe(true)
 		})
 	})
 })

--- a/packages/job-worker/src/blueprints/context/OnSetAsNextContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnSetAsNextContext.ts
@@ -38,7 +38,8 @@ export class OnSetAsNextContext
 		private playoutModel: PlayoutModel,
 		showStyle: ReadonlyDeep<ProcessedShowStyleCompound>,
 		watchedPackages: WatchedPackagesHelper,
-		private partAndPieceInstanceService: PartAndPieceInstanceActionService
+		private partAndPieceInstanceService: PartAndPieceInstanceActionService,
+		public readonly manuallySelected: boolean
 	) {
 		super(contextInfo, context, showStyle, watchedPackages)
 	}

--- a/packages/job-worker/src/blueprints/context/OnTakeContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnTakeContext.ts
@@ -27,6 +27,7 @@ import { BlueprintQuickLookInfo } from '@sofie-automation/blueprints-integration
 
 export class OnTakeContext extends ShowStyleUserContext implements IOnTakeContext, IEventContext {
 	public isTakeAborted: boolean
+	public partToQueue: { rawPart: IBlueprintPart; rawPieces: IBlueprintPiece[] } | undefined
 
 	public get quickLoopInfo(): BlueprintQuickLookInfo | null {
 		return this.partAndPieceInstanceService.quickLoopInfo
@@ -147,6 +148,10 @@ export class OnTakeContext extends ShowStyleUserContext implements IOnTakeContex
 		payload: Record<string, any>
 	): Promise<TSR.ActionExecutionResult> {
 		return executePeripheralDeviceAction(this._context, deviceId, null, actionId, payload)
+	}
+
+	queuePartAfterTake(rawPart: IBlueprintPart, rawPieces: IBlueprintPiece[]): void {
+		this.partToQueue = { rawPart, rawPieces }
 	}
 
 	getCurrentTime(): number {

--- a/packages/job-worker/src/playout/setNext.ts
+++ b/packages/job-worker/src/playout/setNext.ts
@@ -176,7 +176,7 @@ async function setNextPartAndCheckForPendingMoveNextPart(
 
 		playoutModel.setPartInstanceAsNext(newPartInstance, setManually, consumesQueuedSegmentId, nextTimeOffset)
 
-		return executeOnSetAsNextCallback(playoutModel, newPartInstance, context)
+		return executeOnSetAsNextCallback(playoutModel, newPartInstance, context, setManually)
 	} else {
 		// Set to null
 
@@ -188,7 +188,8 @@ async function setNextPartAndCheckForPendingMoveNextPart(
 async function executeOnSetAsNextCallback(
 	playoutModel: PlayoutModel,
 	newPartInstance: PlayoutPartInstanceModel,
-	context: JobContext
+	context: JobContext,
+	setManually: boolean
 ) {
 	const NOTIFICATION_CATEGORY = 'onSetAsNext'
 
@@ -218,7 +219,8 @@ async function executeOnSetAsNextCallback(
 		playoutModel,
 		showStyle,
 		watchedPackagesHelper,
-		new PartAndPieceInstanceActionService(context, playoutModel, showStyle, rundownOfNextPart)
+		new PartAndPieceInstanceActionService(context, playoutModel, showStyle, rundownOfNextPart),
+		setManually
 	)
 
 	// Clear any existing notifications for this partInstance. This will clear any from the previous setAsNext

--- a/packages/job-worker/src/playout/take.ts
+++ b/packages/job-worker/src/playout/take.ts
@@ -198,7 +198,13 @@ export async function performTakeToNextedPart(
 	const showStyle = await pShowStyle
 	const blueprint = await context.getShowStyleBlueprint(showStyle._id)
 
-	const { isTakeAborted } = await executeOnTakeCallback(context, playoutModel, showStyle, blueprint, currentRundown)
+	const { isTakeAborted, queuePart } = await executeOnTakeCallback(
+		context,
+		playoutModel,
+		showStyle,
+		blueprint,
+		currentRundown
+	)
 
 	if (isTakeAborted) {
 		await updateTimeline(context, playoutModel)
@@ -264,8 +270,12 @@ export async function performTakeToNextedPart(
 		resetPreviousSegmentIfLooping(context, playoutModel)
 	}
 
-	// Once everything is synced, we can choose the next part
-	await setNextPart(context, playoutModel, nextPart, false)
+	if (queuePart) {
+		await queuePart()
+	} else {
+		// Once everything is synced, we can choose the next part
+		await setNextPart(context, playoutModel, nextPart, false)
+	}
 
 	// If the Hold is PENDING, make it active
 	if (playoutModel.playlist.holdState === RundownHoldState.PENDING) {
@@ -289,10 +299,11 @@ async function executeOnTakeCallback(
 	showStyle: ReadonlyObjectDeep<ProcessedShowStyleCompound>,
 	blueprint: ReadonlyObjectDeep<WrappedShowStyleBlueprint>,
 	currentRundown: PlayoutRundownModel
-): Promise<{ isTakeAborted: boolean }> {
+): Promise<{ isTakeAborted: boolean; queuePart: (() => Promise<void>) | undefined }> {
 	const NOTIFICATION_CATEGORY = 'onTake'
 
 	let isTakeAborted = false
+	let queuePart: (() => Promise<void>) | undefined = undefined
 	if (blueprint.blueprint.onTake) {
 		const rundownId = currentRundown.rundown._id
 		const partInstanceId = playoutModel.playlist.nextPartInfo?.partInstanceId
@@ -300,6 +311,7 @@ async function executeOnTakeCallback(
 
 		// Clear any existing notifications for this partInstance. This will clear any from the previous take
 		playoutModel.clearAllNotifications(NOTIFICATION_CATEGORY)
+		const actionService = new PartAndPieceInstanceActionService(context, playoutModel, showStyle, currentRundown)
 
 		const watchedPackagesHelper = WatchedPackagesHelper.empty(context)
 		const onSetAsNextContext = new OnTakeContext(
@@ -313,12 +325,18 @@ async function executeOnTakeCallback(
 			playoutModel,
 			showStyle,
 			watchedPackagesHelper,
-			new PartAndPieceInstanceActionService(context, playoutModel, showStyle, currentRundown)
+			actionService
 		)
 		try {
 			await blueprint.blueprint.onTake(onSetAsNextContext)
 			await applyOnTakeSideEffects(context, playoutModel, onSetAsNextContext)
 			isTakeAborted = onSetAsNextContext.isTakeAborted
+			if (onSetAsNextContext.partToQueue) {
+				const partToQueue = onSetAsNextContext.partToQueue
+				queuePart = async () => {
+					await actionService.queuePart(partToQueue.rawPart, partToQueue.rawPieces)
+				}
+			}
 
 			for (const note of onSetAsNextContext.notes) {
 				// Update the notifications. Even though these are related to a partInstance, they will be cleared on the next take
@@ -346,7 +364,7 @@ async function executeOnTakeCallback(
 			})
 		}
 	}
-	return { isTakeAborted }
+	return { isTakeAborted, queuePart }
 }
 
 async function applyOnTakeSideEffects(context: JobContext, playoutModel: PlayoutModel, onTakeContext: OnTakeContext) {


### PR DESCRIPTION
- in onTake: allows a part to be queued after the taken part
- in onSetAsNext: provides information whether it is the user that initiated setting a part as next