### PR TITLE
feat(EAV-880): add `createdByAdLib` to ActivePlaylistTopic parts

### DIFF
--- a/packages/live-status-gateway-api/api/components/part/partBase/partBase-example.yaml
+++ b/packages/live-status-gateway-api/api/components/part/partBase/partBase-example.yaml
@@ -1,3 +1,4 @@
 id: 'H5CBGYjThrMSmaYvRaa5FVKJIzk_'
 name: 'Intro'
 autoNext: false
+createdByAdLib: false

--- a/packages/live-status-gateway-api/api/components/part/partBase/partBase.yaml
+++ b/packages/live-status-gateway-api/api/components/part/partBase/partBase.yaml
@@ -9,6 +9,10 @@ $defs:
       name:
         description: User-presentable name of the part
         type: string
+      createdByAdLib:
+        description: Whether this part was created by an adlib
+        type: boolean
+        default: false
       autoNext:
         description: If this part will progress to the next automatically
         type: boolean

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -381,6 +381,10 @@ channels:
                                 name:
                                   description: User-presentable name of the part
                                   type: string
+                                createdByAdLib:
+                                  description: Whether this part was created by an adlib
+                                  type: boolean
+                                  default: false
                                 autoNext:
                                   description: If this part will progress to the next automatically
                                   type: boolean
@@ -392,6 +396,7 @@ channels:
                                 - id: H5CBGYjThrMSmaYvRaa5FVKJIzk_
                                   name: Intro
                                   autoNext: false
+                                  createdByAdLib: false
                             - type: object
                               title: PartStatus
                               properties:
@@ -484,6 +489,7 @@ channels:
                               id: H5CBGYjThrMSmaYvRaa5FVKJIzk_
                               name: Intro
                               autoNext: false
+                              createdByAdLib: false
                         - type: object
                           title: CurrentPartStatus
                           properties:
@@ -531,6 +537,7 @@ channels:
                           id: H5CBGYjThrMSmaYvRaa5FVKJIzk_
                           name: Intro
                           autoNext: false
+                          createdByAdLib: false
                     - type: "null"
                 currentSegment:
                   oneOf:
@@ -624,6 +631,7 @@ channels:
                                     id: H5CBGYjThrMSmaYvRaa5FVKJIzk_
                                     name: Intro
                                     autoNext: false
+                                    createdByAdLib: false
                           required:
                             - timing
                             - parts

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -202,6 +202,10 @@ interface CurrentPartStatus {
 	 */
 	name: string
 	/**
+	 * Whether this part was created by an adlib
+	 */
+	createdByAdLib?: boolean
+	/**
 	 * If this part will progress to the next automatically
 	 */
 	autoNext?: boolean
@@ -343,6 +347,10 @@ interface CurrentSegmentPart {
 	 */
 	name: string
 	/**
+	 * Whether this part was created by an adlib
+	 */
+	createdByAdLib?: boolean
+	/**
 	 * If this part will progress to the next automatically
 	 */
 	autoNext?: boolean
@@ -367,6 +375,10 @@ interface PartStatus {
 	 * User-presentable name of the part
 	 */
 	name: string
+	/**
+	 * Whether this part was created by an adlib
+	 */
+	createdByAdLib?: boolean
 	/**
 	 * If this part will progress to the next automatically
 	 */

--- a/packages/live-status-gateway/src/topics/__tests__/activePlaylist.spec.ts
+++ b/packages/live-status-gateway/src/topics/__tests__/activePlaylist.spec.ts
@@ -135,6 +135,7 @@ describe('ActivePlaylistTopic', () => {
 				id: 'PART_1',
 				name: 'Test Part',
 				segmentId: 'SEGMENT_1',
+				createdByAdLib: false,
 				timing: { startTime: 1600000060000, expectedDurationMs: 10000, projectedEndTime: 1600000070000 },
 				pieces: [],
 				autoNext: undefined,
@@ -151,6 +152,7 @@ describe('ActivePlaylistTopic', () => {
 					{
 						id: 'PART_1',
 						name: 'Test Part',
+						createdByAdLib: false,
 						timing: {
 							expectedDurationMs: 10000,
 						},
@@ -171,6 +173,85 @@ describe('ActivePlaylistTopic', () => {
 		expect(JSON.parse(mockSubscriber.send.mock.calls[0][0] as string)).toMatchObject(
 			JSON.parse(JSON.stringify(expectedStatus))
 		)
+	})
+
+	it('marks adlib-created parts in active playlist status', async () => {
+		const handlers = makeMockHandlers()
+		const topic = new ActivePlaylistTopic(makeMockLogger(), handlers)
+		const mockSubscriber = makeMockSubscriber()
+
+		const currentPartInstanceId = 'CURRENT_PART_INSTANCE_ID'
+		const nextPartInstanceId = 'NEXT_PART_INSTANCE_ID'
+
+		const playlist = makeTestPlaylist()
+		playlist.activationId = protectString('somethingRandom')
+		playlist.currentPartInfo = {
+			consumesQueuedSegmentId: false,
+			manuallySelected: false,
+			partInstanceId: protectString(currentPartInstanceId),
+			rundownId: playlist.rundownIdsInOrder[0],
+		}
+		playlist.nextPartInfo = {
+			consumesQueuedSegmentId: false,
+			manuallySelected: false,
+			partInstanceId: protectString(nextPartInstanceId),
+			rundownId: playlist.rundownIdsInOrder[0],
+		}
+		handlers.playlistHandler.notify(playlist)
+
+		const testShowStyleBase = makeTestShowStyleBase()
+		handlers.showStyleBaseHandler.notify(testShowStyleBase as ShowStyleBaseExt)
+
+		const segment1id = protectString('SEGMENT_1')
+		const currentPart: Partial<DBPart> = {
+			_id: protectString('PART_1'),
+			title: 'Current AdLib Part',
+			segmentId: segment1id,
+			expectedDurationWithTransition: 10000,
+			expectedDuration: 10000,
+		}
+		const nextPart: Partial<DBPart> = {
+			_id: protectString('PART_2'),
+			title: 'Next AdLib Part',
+			segmentId: segment1id,
+			expectedDurationWithTransition: 8000,
+			expectedDuration: 8000,
+		}
+		const testPartInstances: PartialDeep<SelectedPartInstances> = {
+			current: {
+				_id: currentPartInstanceId,
+				part: currentPart,
+				segmentId: segment1id,
+				orphaned: 'adlib-part',
+			},
+			next: {
+				_id: nextPartInstanceId,
+				part: nextPart,
+				segmentId: segment1id,
+				orphaned: 'adlib-part',
+			},
+			firstInSegmentPlayout: {},
+			inCurrentSegment: [
+				literal<PartialDeep<DBPartInstance>>({
+					_id: protectString(currentPartInstanceId),
+					part: currentPart,
+					segmentId: segment1id,
+					orphaned: 'adlib-part',
+				}),
+			] as DBPartInstance[],
+		}
+		handlers.partInstancesHandler.notify(testPartInstances as SelectedPartInstances)
+		handlers.partsHandler.notify([currentPart as DBPart, nextPart as DBPart])
+		handlers.segmentHandler.notify({
+			_id: segment1id,
+		} as DBSegment)
+
+		topic.addSubscriber(mockSubscriber)
+
+		const sentStatus = JSON.parse(mockSubscriber.send.mock.calls[0][0] as string) as ActivePlaylistEvent
+		expect(sentStatus.currentPart?.createdByAdLib).toBe(true)
+		expect(sentStatus.nextPart?.createdByAdLib).toBe(true)
+		expect(sentStatus.currentSegment?.parts[0].createdByAdLib).toBe(true)
 	})
 
 	it('provides segment and part with segment timing', async () => {
@@ -239,6 +320,7 @@ describe('ActivePlaylistTopic', () => {
 				id: 'PART_1',
 				name: 'Test Part',
 				segmentId: 'SEGMENT_1',
+				createdByAdLib: false,
 				timing: { startTime: 1600000060000, expectedDurationMs: 10000, projectedEndTime: 1600000070000 },
 				pieces: [],
 				autoNext: undefined,
@@ -257,6 +339,7 @@ describe('ActivePlaylistTopic', () => {
 					{
 						id: 'PART_1',
 						name: 'Test Part',
+						createdByAdLib: false,
 						timing: {
 							expectedDurationMs: 10000,
 						},

--- a/packages/live-status-gateway/src/topics/activePlaylistTopic.ts
+++ b/packages/live-status-gateway/src/topics/activePlaylistTopic.ts
@@ -114,6 +114,7 @@ export class ActivePlaylistTopic extends WebSocketTopicBase implements WebSocket
 									id: unprotectString(currentPart._id),
 									name: currentPart.title,
 									autoNext: currentPart.autoNext,
+									createdByAdLib: this._currentPartInstance.orphaned === 'adlib-part',
 									segmentId: unprotectString(currentPart.segmentId),
 									timing: calculateCurrentPartTiming(
 										this._currentPartInstance,
@@ -143,19 +144,21 @@ export class ActivePlaylistTopic extends WebSocketTopicBase implements WebSocket
 									),
 								})
 							: null,
-					nextPart: nextPart
-						? literal<PartStatus>({
-								id: unprotectString(nextPart._id),
-								name: nextPart.title,
-								autoNext: nextPart.autoNext,
-								segmentId: unprotectString(nextPart.segmentId),
-								pieces:
-									this._pieceInstancesInNextPartInstance?.map((piece) =>
-										toPieceStatus(piece, this._showStyleBaseExt)
-									) ?? [],
-								publicData: nextPart.publicData,
-							})
-						: null,
+					nextPart:
+						this._nextPartInstance && nextPart
+							? literal<PartStatus>({
+									id: unprotectString(nextPart._id),
+									name: nextPart.title,
+									autoNext: nextPart.autoNext,
+									createdByAdLib: this._nextPartInstance.orphaned === 'adlib-part',
+									segmentId: unprotectString(nextPart.segmentId),
+									pieces:
+										this._pieceInstancesInNextPartInstance?.map((piece) =>
+											toPieceStatus(piece, this._showStyleBaseExt)
+										) ?? [],
+									publicData: nextPart.publicData,
+								})
+							: null,
 					quickLoop: this.transformQuickLoopStatus(),
 					publicData: this._activePlaylist.publicData,
 					playoutState: this._activePlaylist.publicPlayoutPersistentState,

--- a/packages/live-status-gateway/src/topics/helpers/__tests__/segmentParts.test.ts
+++ b/packages/live-status-gateway/src/topics/helpers/__tests__/segmentParts.test.ts
@@ -1,0 +1,53 @@
+import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
+import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { getCurrentSegmentParts } from '../segmentParts.js'
+
+function makePart(id: string, title: string): DBPart {
+	return {
+		_id: protectString(id),
+		_rank: 0,
+		rundownId: protectString('rundown_1'),
+		segmentId: protectString('segment_1'),
+		notes: [],
+		externalId: id,
+		expectedDuration: 1000,
+		expectedDurationWithTransition: 1000,
+		title,
+	}
+}
+
+describe('segmentParts - getCurrentSegmentParts', () => {
+	it('marks adlib-created parts', () => {
+		const adlibPart = makePart('part_1', 'AdLib Part')
+		const normalPart = makePart('part_2', 'Normal Part')
+
+		const result = getCurrentSegmentParts(
+			[
+				{
+					_id: protectString('partInstance_1'),
+					part: adlibPart,
+					orphaned: 'adlib-part',
+				} as DBPartInstance,
+			],
+			[adlibPart, normalPart]
+		)
+
+		expect(result).toEqual([
+			{
+				id: 'part_1',
+				name: 'AdLib Part',
+				autoNext: undefined,
+				createdByAdLib: true,
+				timing: { expectedDurationMs: 1000 },
+			},
+			{
+				id: 'part_2',
+				name: 'Normal Part',
+				autoNext: undefined,
+				createdByAdLib: false,
+				timing: { expectedDurationMs: 1000 },
+			},
+		])
+	})
+})

--- a/packages/live-status-gateway/src/topics/helpers/segmentParts.ts
+++ b/packages/live-status-gateway/src/topics/helpers/segmentParts.ts
@@ -9,10 +9,10 @@ export function getCurrentSegmentParts(
 	segmentPartInstances: DBPartInstance[],
 	segmentParts: DBPart[]
 ): CurrentSegmentPart[] {
-	const partInstancesByPartId: Record<string, { _id: string | PartInstanceId; part: DBPart }> = _.indexBy(
-		segmentPartInstances,
-		(partInstance) => unprotectString(partInstance.part._id)
-	)
+	const partInstancesByPartId: Record<
+		string,
+		{ _id: string | PartInstanceId; part: DBPart; orphaned?: DBPartInstance['orphaned'] }
+	> = _.indexBy(segmentPartInstances, (partInstance) => unprotectString(partInstance.part._id))
 	segmentParts.forEach((part) => {
 		const partId = unprotectString(part._id)
 		if (partInstancesByPartId[partId]) return
@@ -22,13 +22,16 @@ export function getCurrentSegmentParts(
 		}
 		partInstancesByPartId[partId] = partInstance
 	})
-	return Object.values<{ _id: string | PartInstanceId; part: DBPart }>(partInstancesByPartId)
+	return Object.values<{ _id: string | PartInstanceId; part: DBPart; orphaned?: DBPartInstance['orphaned'] }>(
+		partInstancesByPartId
+	)
 		.sort((a, b) => a.part._rank - b.part._rank)
 		.map(
 			(partInstance): CurrentSegmentPart => ({
 				id: unprotectString(partInstance.part._id),
 				name: partInstance.part.title,
 				autoNext: partInstance.part.autoNext,
+				createdByAdLib: partInstance.orphaned === 'adlib-part',
 				timing: {
 					expectedDurationMs: partInstance.part.expectedDuration,
 				},


### PR DESCRIPTION
Will be followed by a PR upstream.

This property lets us filter adlibbed parts in vBox, so that we don't show too much junk when the user cuts between sources a lot, which produces a new adlib part each time