### PR TITLE
chore(EAV-997): show full version in "Publish to CodeArtifact" summary

### DIFF
--- a/.github/workflows/ecr-publish-libs.yaml
+++ b/.github/workflows/ecr-publish-libs.yaml
@@ -273,8 +273,10 @@ jobs:
 
           yarn lerna publish from-package --tag-version-prefix='' --dist-tag $NPM_TAG --yes --no-verify-access
 
-          NEW_VERSION=$(node -p "require('./lerna.json').version")
+          LERNA_VERSION=$(node -p "require('./lerna.json').version")
+          NEW_VERSION=$(node -p "require('./shared-lib/package.json').version")
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "**Published:** $NEW_VERSION as $NPM_TAG" >> $GITHUB_STEP_SUMMARY
+          echo "**Published:** $LERNA_VERSION as $NPM_TAG" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** $NEW_VERSION" >> $GITHUB_STEP_SUMMARY
         env:
           CI: true


### PR DESCRIPTION
Instead of saying just

> **Published:** 26.3.0-2 as nightly

The summary is going to say something like

> **Published:** 26.3.0-2 as nightly
> **Version:** 26.3.0-nightly-EAV-997-20260526-094101-f3cf9ed.0

Making the full NPM (codeartifact) version (tag) slightly more convenient to find